### PR TITLE
GUNDI-2761: Fix issue while caching data

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -182,7 +182,7 @@ async def get_dispatched_observation(
                         delivered_at=observation_trace.delivered_at,
                     )
                     # Save in cache again
-                    cache_dispatched_observation(observation=observation)
+                    await cache_dispatched_observation(observation=observation)
     except redis_exceptions.ConnectionError as e:
         logger.error(
             f"ConnectionError while reading dispatched observations from Cache: {e}",
@@ -197,7 +197,7 @@ async def get_dispatched_observation(
         return observation
 
 
-def cache_dispatched_observation(
+async def cache_dispatched_observation(
     observation: gundi_schemas_v2.DispatchedObservation,
 ):
     try:
@@ -212,7 +212,7 @@ def cache_dispatched_observation(
             ExtraKeys.OutboundIntId: destination_id,
         }
         cache_key = f"dispatched_observation.{gundi_id}.{destination_id}"
-        _cache_db.setex(
+        await _cache_db.setex(
             name=cache_key,
             time=settings.DISPATCHED_OBSERVATIONS_CACHE_TTL,
             value=observation.json(),


### PR DESCRIPTION
### What does this PR do?
- Adds a missing `await` while caching observations. Delivered observations are cached to support things like attachments or updates more efficiently (Although we don't support attachments or updates yet).

### Relevant link(s)
[GUNDI-2761](https://allenai.atlassian.net/browse/GUNDI-2761)



[GUNDI-2761]: https://allenai.atlassian.net/browse/GUNDI-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ