### PR TITLE
GUNDI-3161: Update the smart client to avoid basic-auth

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -261,7 +261,7 @@ shapely==2.0.2
     # via smartconnect-client
 six==1.16.0
     # via python-dateutil
-smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
+smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
     # via -r requirements.in
 sniffio==1.3.0
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ hiredis==2.3.2
 gundi-core==1.3.0
 gundi-client==0.2.2
 gundi-client-v2==2.1.7
-https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
+https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 httpx==0.24.1
 gcloud-aio-pubsub==6.0.0
 gcloud-aio-storage==9.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -244,7 +244,7 @@ shapely==2.0.2
     # via smartconnect-client
 six==1.16.0
     # via python-dateutil
-smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
+smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
     # via -r requirements.in
 sniffio==1.3.0
     # via


### PR DESCRIPTION
Updates the smart client to avoid basic-auth. This is a mitigation attempt for the issue where SMART servers take minutes or timeout to respond to requests.