### PR TITLE
Fix issue building destination urls in v2

### DIFF
--- a/app/services/dispatchers.py
+++ b/app/services/dispatchers.py
@@ -59,7 +59,8 @@ class SmartConnectDispatcherV2(DispatcherV2, ABC):
             if url_parse.port
             else url_parse.hostname
         )
-        path = url_parse.path or "server"
+        path = url_parse.path or "/server"
+        path = path.replace("//", "/")
         api_url = (
             getattr(auth_config, "endpoint", None)
             or f"{url_parse.scheme}://{domain}{path}"


### PR DESCRIPTION
This PR fixes an issue in the SMART Dispatcher v2 where we are enforcing the path `/server` in the destination url. Some sites like tfuas have a different installation and then their APIs live in a different path like `/fire`. This fix will honor the original path and port if set, and will also allow overriding the whole url by settings an "endpoint" attribute at config level.